### PR TITLE
ci: limit terraform plan workflow to only run when terraform files change

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "tf/**"
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
this should help with the pull requests submitted by dependabot, and it also seemed weird to me to run a `terraform plan` on almost every PR when we really only need to know about this output when the terraform source code changes.